### PR TITLE
Removing Hard-Coded Local Paths to Data Directory

### DIFF
--- a/bodymocap/body_mocap_api.py
+++ b/bodymocap/body_mocap_api.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import os
 import cv2
 import sys
 import torch
@@ -21,7 +22,7 @@ class BodyMocap(object):
     def __init__(self, regressor_checkpoint, smpl_dir, device=torch.device('cuda'), use_smplx=False):
 
         self.device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
-
+        extra_data_dir = os.path.dirname(smpl_dir)
         # Load parametric model (SMPLX or SMPL)
         if use_smplx:
             smplModelPath = smpl_dir + '/SMPLX_NEUTRAL.pkl'
@@ -33,11 +34,11 @@ class BodyMocap(object):
             self.use_smplx = True
         else:
             smplModelPath = smpl_dir + '/basicModel_neutral_lbs_10_207_0_v1.0.0.pkl'
-            self.smpl = SMPL(smplModelPath, batch_size=1, create_transl=False).to(self.device)
+            self.smpl = SMPL(smplModelPath, batch_size=1, create_transl=False, extra_data_dir=extra_data_dir).to(self.device)
             self.use_smplx = False
             
-        #Load pre-trained neural network 
-        SMPL_MEAN_PARAMS = './extra_data/body_module/data_from_spin/smpl_mean_params.npz'
+        #Load pre-trained neural network
+        SMPL_MEAN_PARAMS = os.path.join(extra_data_dir, 'body_module/data_from_spin/smpl_mean_params.npz')
         self.model_regressor = hmr(SMPL_MEAN_PARAMS).to(self.device)
         checkpoint = torch.load(regressor_checkpoint)
         self.model_regressor.load_state_dict(checkpoint['model'], strict=False)

--- a/bodymocap/models/smpl.py
+++ b/bodymocap/models/smpl.py
@@ -1,6 +1,6 @@
 # Original code from SPIN: https://github.com/nkolot/SPIN
 
-
+import os
 import torch
 import numpy as np
 import smplx
@@ -30,7 +30,8 @@ class SMPL(_SMPL):
     def __init__(self, *args, **kwargs):
         super(SMPL, self).__init__(*args, **kwargs)
         joints = [constants.JOINT_MAP[i] for i in constants.JOINT_NAMES]
-        JOINT_REGRESSOR_TRAIN_EXTRA = 'extra_data/body_module/data_from_spin//J_regressor_extra.npy'
+        extra_data_dir = kwargs.get('extra_data_dir', './extra_data')
+        JOINT_REGRESSOR_TRAIN_EXTRA = os.path.join(extra_data_dir, 'body_module/data_from_spin/J_regressor_extra.npy')
         J_regressor_extra = np.load(JOINT_REGRESSOR_TRAIN_EXTRA)
         self.register_buffer('J_regressor_extra', torch.tensor(J_regressor_extra, dtype=torch.float32))
         self.joint_map = torch.tensor(joints, dtype=torch.long)
@@ -58,7 +59,8 @@ class SMPLX(_SMPLX):
         kwargs['ext'] = 'pkl'       #We have pkl file
         super(SMPLX, self).__init__(*args, **kwargs)
         joints = [constants.JOINT_MAP[i] for i in constants.JOINT_NAMES]
-        JOINT_REGRESSOR_TRAIN_EXTRA_SMPLX = 'extra_data/body_module/J_regressor_extra_smplx.npy'
+        extra_data_dir = kwargs.get('extra_data_dir', './extra_data')
+        JOINT_REGRESSOR_TRAIN_EXTRA_SMPLX = os.path.join(extra_data_dir, 'body_module/J_regressor_extra_smplx.npy')
         J_regressor_extra = np.load(JOINT_REGRESSOR_TRAIN_EXTRA_SMPLX)           #(9, 10475)
         self.register_buffer('J_regressor_extra', torch.tensor(J_regressor_extra, dtype=torch.float32))
         self.joint_map = torch.tensor(joints, dtype=torch.long)

--- a/handmocap/hand_mocap_api.py
+++ b/handmocap/hand_mocap_api.py
@@ -28,7 +28,7 @@ class HandMocap:
         self.opt.single_branch = True
         self.opt.main_encoder = "resnet50"
         # self.opt.data_root = "/home/hjoo/dropbox/hand_yu/data/"
-        self.opt.model_root = "./extra_data"
+        self.opt.model_root = os.path.dirname(smpl_dir)
         self.opt.smplx_model_file = os.path.join(smpl_dir,'SMPLX_NEUTRAL.pkl')
 
         self.opt.batchSize = 1


### PR DESCRIPTION
Hi,

Thanks for the great work.

One issue is that the links to ./local_data are hard-coded which makes it very difficult to run the mocap code from a different directory than the source folder.

I committed a quick fix which is just to use the parent directory of the `smpl_dir` as the `extra_data directory` name since this required the minimum number of code changes. I think a better solution might be to take in `extra_data_dir` as an optional parameter for `BodyMocap` and `HandMocap`, but this may change the api a bit.