### PR TITLE
Missing quote in the download_data_body_module.sh

### DIFF
--- a/scripts/download_data_body_module.sh
+++ b/scripts/download_data_body_module.sh
@@ -30,4 +30,4 @@ wget https://dl.fbaipublicfiles.com/eft/fairmocap_data/body_module/J_regressor_e
 #     echo "There exists sample_data already"
 # fi
 
-echo "Done
+echo "Done"


### PR DESCRIPTION
Missing quote leads to error when executing `download_data_body_module.sh `