### PR TITLE
added the missing quote after DONE

### DIFF
--- a/scripts/download_data_body_module.sh
+++ b/scripts/download_data_body_module.sh
@@ -30,4 +30,4 @@ wget https://dl.fbaipublicfiles.com/eft/fairmocap_data/body_module/J_regressor_e
 #     echo "There exists sample_data already"
 # fi
 
-echo "Done
+echo "Done"


### PR DESCRIPTION
there is a missing quote after DONE that I discovered and Jason helped me to fix it. Here's a pull that fixes it:

https://github.com/facebookresearch/phosa/issues/8#issuecomment-739574176

@jasonyzhang 