### PR TITLE
to fix issue #66 where opendr will fail to install

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -11,7 +11,7 @@
   conda activate venv_frankmocap
 
   # Install ffmpeg
-  sudo apt-get install ffmpeg
+  sudo apt-get install ffmpeg libosmesa6-dev
 
   # Install cuda 
   # Choose versions based on your system. For example:


### PR DESCRIPTION
opendr depends on osmesa (off screen MESA rendering). This is not installed on all systems by default